### PR TITLE
add better labeling for queries that had previously been unnamed

### DIFF
--- a/lib/rspec/activerecord/helpers/report.rb
+++ b/lib/rspec/activerecord/helpers/report.rb
@@ -26,6 +26,7 @@ module ActiveRecordFormatterHelpers
 
       File.open(file_path, "wb") do |f|
         f.puts "#{collector.total_objects} AR objects, #{collector.total_queries} AR queries"
+        f.puts "#{collector.groups_encountered} example groups executed"
 
         f.puts ""
         f.puts "Worst Example Groups by Object Creation"


### PR DESCRIPTION
lots of additional detection for queries from the example suite I have
access to. for me, this resolved very nearly every query.