### PR TITLE
Support Rails 7 and Ruby 3.2/3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Forked from JMastey temporarily to bump version support to Rails 7
+
 RSpec Active Record Formatter
 =============
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Forked from JMastey temporarily to bump version support to Rails 7
-
 RSpec Active Record Formatter
 =============
 

--- a/lib/rspec/activerecord/helpers/report.rb
+++ b/lib/rspec/activerecord/helpers/report.rb
@@ -22,7 +22,7 @@ module ActiveRecordFormatterHelpers
     end
 
     def write_file(file_path:)
-      Dir.mkdir(report_dir) unless File.exists?(report_dir)
+      Dir.mkdir(report_dir) unless File.exist?(report_dir)
 
       File.open(file_path, "wb") do |f|
         f.puts "#{collector.total_objects} AR objects, #{collector.total_queries} AR queries"

--- a/rspec-activerecord-formatter.gemspec
+++ b/rspec-activerecord-formatter.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.require_paths = %w[ext lib].select { |dir| File.directory?(dir) }
 
-  gem.add_dependency "activesupport", ">= 4.0", "< 7.0"
+  gem.add_dependency "activesupport", ">= 4.0", "< 8.0"
   gem.add_dependency "rspec", ">= 3.4"
 
   gem.add_development_dependency "coveralls", "~> 0.8"


### PR DESCRIPTION
* Ruby 3.2 removed the `exists?` alias
* Rails 7.x needs > activesupport 7.0

With these minor changes, this remains compatible! We made these in our org repo, figured we should offer them back to the source. 

Co-authored-by: Leo Gonzalez <leonardo.gonzalez@homechef.com>
Co-authored-by: Trey Perkins <trey.perkins@homechef.com>